### PR TITLE
Quote variables in Products.Transience manage_container to avoid XSS.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.1 (unreleased)
 ----------------
 
+- Quote variables in Products.Transience manage_container to avoid XSS.
+  From Products.PloneHotfix20160830.  [maurits]
+
 
 4.0 (2016-07-23)
 ----------------

--- a/src/Products/Transience/dtml/manageTransientObjectContainer.dtml
+++ b/src/Products/Transience/dtml/manageTransientObjectContainer.dtml
@@ -36,7 +36,7 @@ Transient data will persist, but only for a user-specified period of time
     </div>
   </td>
   <td align="left" valign="top">
-    <input type="text" name="title" size=30 value="&dtml-title;">
+    <input type="text" name="title" size=30 value='<dtml-var name="title" html_quote>'>
   </td>
 </tr>
 <tr>
@@ -50,7 +50,7 @@ Transient data will persist, but only for a user-specified period of time
   </td>
   <td align="left" valign="top">
     <input type="text" name="timeout_mins:int" size=10
-     value=&dtml-getTimeoutMinutes;>
+           value='<dtml-var name="getTimeoutMinutes" html_quote>'>
   </td>
 </tr>
 
@@ -70,7 +70,7 @@ Transient data will persist, but only for a user-specified period of time
   </td>
   <td align="left" valign="top">
     <input type="text" name="period_secs:int" size=10
-     value=&dtml-getPeriodSeconds;>
+      value='<dtml-var name="getPeriodSeconds" html_quote>'>
   </td>
 </tr>
 
@@ -85,7 +85,7 @@ Transient data will persist, but only for a user-specified period of time
   </td>
   <td align="left" valign="top">
     <input type="text" name="limit:int" size=10
-     value=&dtml-getSubobjectLimit;>
+      value='<dtml-var name="getSubobjectLimit" html_quote>'>
   </td>
 </tr>
 
@@ -100,7 +100,7 @@ Transient data will persist, but only for a user-specified period of time
   </td>
   <td align="left" valign="top">
      <input type="text" name="addNotification"
-     	value="&dtml-getAddNotificationTarget;" size=40>
+       value='<dtml-var name="getAddNotificationTarget" html_quote>' size=40>
   </td>
 </tr>
 
@@ -115,7 +115,7 @@ Transient data will persist, but only for a user-specified period of time
   </td>
   <td align="left" valign="top">
      <input type="text" name="delNotification"
-     	value="&dtml-getDelNotificationTarget;" size=40>
+      value='<dtml-var name="getDelNotificationTarget" html_quote>' size=40>
   </td>
 </tr>
 


### PR DESCRIPTION
From Products.PloneHotfix20160830.

This matches what is done in this Zope 2.13 pull request: https://github.com/zopefoundation/Zope/pull/67