### PR TITLE
Fix Access permissions for meta_type and zmi_icon properties so they …

### DIFF
--- a/src/Products/Transience/Transience.py
+++ b/src/Products/Transience/Transience.py
@@ -123,15 +123,7 @@ class MaxTransientObjectsExceeded(Exception):
 class TransientObjectContainer(SimpleItem):
     """ Object which contains items that are automatically flushed
     after a period of inactivity """
-
-    meta_type = "Transient Object Container"
-    zmi_icon = 'far fa-clock'
-
-    manage_options = (
-        {'label': 'Manage', 'action': 'manage_container'},
-        {'label': 'Security', 'action': 'manage_access'},
-    )
-
+    
     security = ClassSecurityInfo()
     security.setPermissionDefault(
         MANAGE_CONTAINER_PERM,
@@ -152,6 +144,19 @@ class TransientObjectContainer(SimpleItem):
     security.setPermissionDefault(
         CREATE_TRANSIENTS_PERM,
         ['Manager', ],
+    )
+
+    meta_type = "Transient Object Container"
+    zmi_icon = 'far fa-clock'
+    security.declareProtected(ACCESS_CONTENTS_PERM,  # NOQA: flake8: D001
+                              'meta_type')
+    security.declareProtected(ACCESS_CONTENTS_PERM,  # NOQA: flake8: D001
+                              'zmi_icon')
+    
+    
+    manage_options = (
+        {'label': 'Manage', 'action': 'manage_container'},
+        {'label': 'Security', 'action': 'manage_access'},
     )
 
     security.declareProtected(MGMT_SCREEN_PERM,  # NOQA: flake8: D001


### PR DESCRIPTION
…don't raise when accessed in the admin interface.

I'm entirely not sure those permissions are correct. From reading the code it seems that `MGMT_SCREEN_PERM` seems like a more logical choice, but that doesn't fix the error.

Back to what error this actually fixes: When navigating to `/temp_folder/manage_main` the `session_data` object would render as a broken-object, because accessing the `zmi_icon` or `meta_type` attribute would raise an Access Denied error, which was then swallowed by the 'default' declaration in OFS/zpt/main.zpt where these attributes are actually used.