### PR TITLE
Fix sorting on python3 as list.sort() doesn't accept a cmp function a…

### DIFF
--- a/src/Products/Transience/TransientObject.py
+++ b/src/Products/Transience/TransientObject.py
@@ -18,6 +18,7 @@ import os
 import random
 import sys
 import time
+from functools import cmp_to_key
 
 from six.moves import _thread as thread
 
@@ -253,7 +254,7 @@ class TransientObject(Persistent, Implicit):
 
         # We return the state which was most recently modified, if
         # possible.
-        states.sort(lastmodified_sort)
+        states.sort(key=cmp_to_key(lastmodified_sort))
         if states[0].get('_last_modified'):
             DEBUG and TLOG('TO _p_rc: returning last mod state')
             return states[0]
@@ -263,7 +264,7 @@ class TransientObject(Persistent, Implicit):
         # the object that was most recently accessed (last pulled out of
         # our parent).  This will return an essentially arbitrary state if
         # all last_accessed values are equal.
-        states.sort(lastaccessed_sort)
+        states.sort(key=cmp_to_key(lastaccessed_sort))
         DEBUG and TLOG('TO _p_rc: returning last_accessed state')
         return states[0]
 

--- a/src/Products/Transience/tests/testTransientObject.py
+++ b/src/Products/Transience/tests/testTransientObject.py
@@ -137,6 +137,58 @@ class TestTransientObject(TestCase):
         t = self.t.new('password-storing-session')
         t.set('__ac_password__', 'secret')
         self.assertNotIn('secret', repr(t), '__repr__ leaks: %s' % repr(t))
+    
+    def test_p_resolveConflict_doesnt_fail_on_wrong_sort_usage(self):
+        transient_object = self.t.new('fnord')
+        
+        # objects with _last_modified
+        saved = {
+            'token': '63234647A8.Wt5y4vrs', 
+            'id': '15589683027087205627414298864', 
+            '_created': 1558968302.813777, 
+            '_last_accessed': 1558968302.813777, 
+            '_last_modified': 1558968303.205633
+        }
+        state1 = {
+            'token': '63234647A8.Wt5y4vrs', 
+            'id': '15589683027087205627414298864', 
+            '_created': 1558968302.813777, 
+            '_last_accessed': 1558968302.813777, 
+            '_last_modified': 1558968304.196779
+        }
+        state2 = {
+            'token': '63234647A8.Wt5y4vrs', 
+            'id': '15589683027087205627414298864', 
+            '_created': 1558968302.813777, 
+            '_last_accessed': 1558968302.813777, 
+            '_last_modified': 1558968304.079772
+        }
+        
+        # should not raise
+        transient_object._p_resolveConflict(saved, state1, state2)
+        
+        # objects with only _last_accessed
+        saved = {
+            'token': '63234647A8.Wt5y4vrs', 
+            'id': '15589683027087205627414298864', 
+            '_created': 1558968302.813777, 
+            '_last_accessed': 1558968302.813777
+        }
+        state1 = {
+            'token': '63234647A8.Wt5y4vrs', 
+            'id': '15589683027087205627414298864', 
+            '_created': 1558968302.813777, 
+            '_last_accessed': 1558968302.813777
+        }
+        state2 = {
+            'token': '63234647A8.Wt5y4vrs', 
+            'id': '15589683027087205627414298864', 
+            '_created': 1558968302.813777, 
+            '_last_accessed': 1558968302.813777
+        }
+        
+        # should not raise
+        transient_object._p_resolveConflict(saved, state1, state2)
 
 
 def test_suite():


### PR DESCRIPTION
…nymore.

As far as I can tell this is purely an incompatibility that happened because `list.sort()` doesn't accept a `cmp` function as argument anymore on python3.