### PR TITLE
Fix linting issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ deps =
 commands =
     mkdir -p {toxinidir}/_build/flake8
     - flake8 --format=html --htmldir={toxinidir}/_build/flake8 --doctests src setup.py
-    flake8 src tests setup.py --doctests
+    flake8 src setup.py --doctests
     isort --check-only --recursive {toxinidir}/src setup.py
 
 whitelist_externals =


### PR DESCRIPTION
... which arise with the new flake8 version.

`tests` is no longer a valid flake8 param, as it is no top level
directory.

As it is a subfolder of the `src` folder, it gets linted anyway.

modified:   tox.ini