### PR TITLE
Use correct version configuration

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,7 @@
 [buildout]
 extends = 
     https://zopefoundation.github.io/Zope/releases/4.x/versions-prod.cfg
+    https://zopefoundation.github.io/Zope/releases/4.x/versions.cfg
 develop = .
 parts = 
     interpreter


### PR DESCRIPTION
ie pin versions of Zope 4, which still supports Python 2.7.

modified:   buildout.cfg