### PR TITLE
Pin Zope <5 to retain Python 2 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 4.9 (unreleased)
 ----------------
 
+- Pin Zope <5 to retain Python 2 compatibility
+
 
 4.8 (2020-08-21)
 ----------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,6 +8,7 @@ parts =
 
 [versions]
 Products.Sessions =
+Zope = <5
 
 [interpreter]
 recipe = zc.recipe.egg


### PR DESCRIPTION
modified:   CHANGES.rst
modified:   buildout.cfg