### PR TITLE
Revert "Pin Zope <5 to retain Python 2 compatibility"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,6 @@ Changelog
 4.9 (unreleased)
 ----------------
 
-- Pin Zope <5 to retain Python 2 compatibility
-
 
 4.8 (2020-08-21)
 ----------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,7 +8,6 @@ parts =
 
 [versions]
 Products.Sessions =
-Zope = <5
 
 [interpreter]
 recipe = zc.recipe.egg


### PR DESCRIPTION
Reverts zopefoundation/Products.Sessions#37

As zopefoundation/Zope#919 is now merged this PR is no longer needed.
