### PR TITLE
Reduce usage of deprecated ``tempstorage`` for testing and remove warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.10 (unreleased)
 -----------------
 
+- Reduce usage of deprecated ``tempstorage`` for testing and remove warnings
+  (`#41 <https://github.com/zopefoundation/Products.Sessions/issues/41>`_)
+
 
 4.9 (2021-03-16)
 ----------------

--- a/src/Products/Sessions/stresstests/stresstestMultiThread.py
+++ b/src/Products/Sessions/stresstests/stresstestMultiThread.py
@@ -25,13 +25,12 @@ import Acquisition
 import transaction
 import ZODB  # in order to get Persistence.Persistent working
 from OFS.Application import Application
+from OFS.Folder import Folder
 from Testing import makerequest
 from ZODB.DemoStorage import DemoStorage
 from ZODB.POSException import BTreesConflictError
 from ZODB.POSException import ConflictError
 from ZODB.POSException import ReadConflictError
-
-from Products.TemporaryFolder.TemporaryFolder import MountedTemporaryFolder
 
 import Products.Transience.Transience
 import Products.Transience.TransientObject
@@ -86,7 +85,7 @@ class Foo(Acquisition.Implicit):
 
 def _populate(app):
     bidmgr = BrowserIdManager(idmgr_name)
-    tf = MountedTemporaryFolder(tf_name, 'Temporary Folder')
+    tf = Folder(tf_name)
     toc = TransientObjectContainer(
         toc_name,
         title='Temporary '

--- a/src/Products/Sessions/tests/testInitialization.py
+++ b/src/Products/Sessions/tests/testInitialization.py
@@ -41,7 +41,7 @@ instancehome {instancehome}
       name temporary storage for sessioning
     </temporarystorage>
     mount-point /temp_folder
-   container-class Products.TemporaryFolder.TemporaryContainer
+    container-class OFS.Folder.Folder
 </zodb_db>
 """
 


### PR DESCRIPTION
Fixes #41 

There's a single unit test that requires `Products.TemporaryFolder` and warnings are suppressed for that one. All other tests just use `OFS.Folder` as the temporary folder.