### PR TITLE
Reinstate simple sessioning with `Products.TemporaryFolder`

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -15,7 +15,7 @@ with-future-python = false
 use-flake8 = true
 
 [coverage]
-fail-under = 89
+fail-under = 93
 
 [isort]
 known_first_party = "Products.Transience, Products.TemporaryFolder"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 4.11 (unreleased)
 -----------------
 
+- Improve out-of-the-box experience by instantiating a session data container
+  if the session data manager uses the default configuration that points
+  to a temporary folder
+
+- Reinstate simple sessioning with ``Products.TemporaryFolder``
+  (`#43 <https://github.com/zopefoundation/Products.Sessions/issues/43>`_)
+
 
 4.10 (2021-07-02)
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -19,34 +19,19 @@ Zope server side session management.
 
 This package contains ``Products.Sessions`` and ``Products.Transience``.
 
+Please note
+-----------
+Before release 5.2 of the ``tempstorage`` package sessioning configurations
+using the simple temporary folder implementation shown below were discouraged
+because the temporary storage backend could lose data. This is no longer the
+case.
 
-Using sessions under Zope 4
----------------------------
-The default session support under Zope 2 relied on ``Products.TemporaryFolder``
-for storing session data, which in turn used the ``tempstorage`` package.
-``tempstorage`` is no longer recommended because it has unfixed and possibly
-unfixable issues under Zope 4 that lead to corrupted temporary storages.
-
-If you use sessions sparingly and don't write to them often, a quick workaround
-is to remove the existing ``/temp_folder`` instance in the ZODB if it still is
-a `Temporary Folder` and create a normal `Folder` object named ``temp_folder``
-in its stead. Inside that new ``/temp_folder``, create a
-`Transient Object Container` with the ID ``session_data``. Now session data
-will be stored in the main ZODB.
-
-If you use sessions heavily, or if the workaround above leads to an
-unacceptable number of ZODB conflict errors, you should either try using
-cookies or local browser storage via Javascript for storing session data, or 
-switch to a different session implementation that does not store session data
-in the ZODB at all. See `the Zope book on Sessions for details 
-<https://zope.readthedocs.io/en/latest/zopebook/Sessions.html#alternative-server-side-session-backends-for-zope-4>`_.
-
-
-Using sessions under Zope 2
----------------------------
-If you use the standard Zope session implementation, don't forget to add
-or uncomment the temporary storage database definition in your Zope
-configuration::
+Using sessions with Zope
+------------------------
+For simple RAM memory-based sessioning support, suitable for smaller
+deployments with a single Zope application server instance, add or uncomment
+the following temporary storage database definition in your Zope configuration
+file::
 
   <zodb_db temporary>
       <temporarystorage>
@@ -55,3 +40,13 @@ configuration::
       mount-point /temp_folder
       container-class Products.TemporaryFolder.TemporaryContainer
   </zodb_db>
+
+After a Zope restart, visit the Zope Management Interface and select
+ZODB Mount Point from the list of addable items to instantiate the temporary
+folder mount point. This only needs to be done once. After that point the
+``temp_folder`` object will be recreated on each Zope restart and the session
+support will automatically put a session data container into the temporary
+folder.
+
+For more advanced scenarios see the `Zope book chapter on Session management
+<https://zope.readthedocs.io/en/latest/zopebook/Sessions.html#alternative-server-side-session-backends-for-zope-4>`_.

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'zope.interface',
     ],
     extras_require={
-        'tests': ['Products.TemporaryFolder >= 5'],
+        'tests': ['Products.TemporaryFolder >= 6.2'],
     },
     include_package_data=True,
     zip_safe=False,

--- a/src/Products/Sessions/dtml/manageDataManager.dtml
+++ b/src/Products/Sessions/dtml/manageDataManager.dtml
@@ -59,6 +59,119 @@
 
   </form>
 
+  <dtml-if usesDefaultSessionDataContainer>
+
+    <dtml-with getDefaultSessionDataContainerSettings mapping>
+
+      <hr/>
+
+      <h4>Session data container settings</h4>
+
+      <p class="form-help mb-4">
+        When you use the default session data container at
+        <code>/temp_folder/session_data</code> it will be recreated every time
+        Zope starts. Settings done on the session data container itself will
+        then be set to the values you provide here.
+      </p>
+
+      <form action="manage_changeSDCDefaults" method="post">
+
+        <div class="form-group row">
+          <label for="title" class="col-sm-3 col-md-2">Title</label>
+          <div class="col-sm-9 col-md-10">
+            <input id="title" class="form-control" type="text" name="title"
+                   value="<dtml-var name="title" html_quote>" />
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <label for="timeout_mins" class="col-sm-3 col-md-2">
+            Data object timeout
+          </label>
+          <div class="col-sm-9 col-md-10">
+            <input id="timeout_mins" class="form-control"
+                   type="text" name="timeout_mins:int"
+                   value="<dtml-var name="timeout_mins" html_quote>" />
+            <small class="text-muted">
+              Data object timeout in minutes, <em>0</em> means
+              <em>no expiration</em>
+            </small>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <label for="period_secs" class="col-sm-3 col-md-2">Resolution</label>
+          <div class="col-sm-9 col-md-10">
+            <input id="period_secs" class="form-control" type="text"
+                   name="period_secs:int"
+                   value="<dtml-var name="period_secs" html_quote>" />
+            <small class="text-muted">
+              Timeout resolution in seconds:
+              The value defines the <em>resolution</em> of the item timeout.
+              Setting this higher allows the transience machinery to do
+              fewer <em>writes</em> at the expense of causing items to
+              time out later than the <em>Data object timeout value</em>
+              by a factor of (at most) this many seconds. This number
+              must divide evenly into the number of timeout seconds
+              (<em>Data object timeout value</em> * 60) and  cannot be
+              set higher than the timeout value in seconds. If you are unsure
+              use the default value of <em>20</em>.
+            </small>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <label for="limit" class="col-sm-3 col-md-2">Limit</label>
+          <div class="col-sm-9 col-md-10">
+            <input id="limit" class="form-control" type="text" name="limit:int"
+                   value="<dtml-var name="limit" html_quote>" />
+            <small class="text-muted">
+              Maximum number of subobjects; <em>0</em> means <em>infinite</em>
+            </small>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <label for="addNotification" class="col-sm-3 col-md-2">
+            Add-Notice
+          </label>
+          <div class="col-sm-9 col-md-10">
+            <input id="addNotification" class="form-control" type="text"
+                   name="addNotification"
+                   value="<dtml-var expr="addNotification" html_quote>" />
+            <small class="text-muted">
+              Script to call upon object add (optional), e.g.
+              <em>/somefolder/addScript</em>
+            </small>
+          </div>
+        </div>
+
+        <div class="form-group row">
+          <label for="delNotification" class="col-sm-3 col-md-2">
+            Delete-Notice
+          </label>
+          <div class="col-sm-9 col-md-10">
+            <input id="delNotification" class="form-control" type="text"
+                   name="delNotification"
+                   value="<dtml-var expr="delNotification" html_quote>" />
+            <small class="text-muted">
+              Script to call upon object delete (optional), e.g.
+              <em>/somefolder/delScript</em>
+            </small>
+          </div>
+        </div>
+
+        <div class="zmi-controls">
+          <input class="btn btn-primary" type="submit" name="submit"
+                 value="Change" />
+        </div>
+
+      </form>
+
+    </dtml-with>
+
+  </dtml-if>
+
 </main>
 
 <dtml-var manage_page_footer>

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run {envbindir}/test {posargs:-cv}
     coverage html
-    coverage report -m --fail-under=89
+    coverage report -m --fail-under=93
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Fixes #43 

This PR rehabilitates the simple sessioning implementation using `Products.TemporaryFolder`. All warnings have been removed.

It also improves the experience for those situations where the default for the session data container inside the temporary folder is used (`/temp_folder/session_data`) by automatically instantiating the session data container if `/temp_folder` is mounted, and by providing a way to specify the settings for the session data container because it is automatically recreated every time Zope starts. These default settings used to be stored in the Zope configuration file in Zope 2.