### PR TITLE
Add ability to set the session cookie's ``SameSite`` flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ jobs:
         - ["3.9",   "coverage"]
 
     runs-on: ${{ matrix.os }}-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 [meta]
 template = "zope-product"
-commit-id = "efb3f62f0f2d8deea657bae8db49a191698e62ef"
+commit-id = "b5df3766ff8923477f3d24729b19504f0c401a2e"
 
 [python]
 with-pypy = false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 4.14 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Add ability to set the session cookie's ``SameSite`` flag.
+  See https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/
+  for some background on how browsers change handling ``SameSite``.
 
 
 4.13 (2022-07-13)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 - Add ability to set the session cookie's ``SameSite`` flag.
   See https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/
   for some background on how browsers change handling ``SameSite``.
+  The behavior of existing sites will not change unless the site administrator
+  changes the cookie configuration explicitly. New browser id managers will use
+  ``Lax`` by default.
 
 
 4.13 (2022-07-13)

--- a/src/Products/Sessions/BrowserIdManager.py
+++ b/src/Products/Sessions/BrowserIdManager.py
@@ -158,7 +158,7 @@ class BrowserIdManager(Item, Persistent, Implicit, RoleManager, Owned, Tabs):
         cookiesecure=0,
         cookiehttponly=0,
         auto_url_encoding=0,
-        cookiesamesite=None,
+        cookiesamesite='Lax',
     ):
         self.id = str(id)
         self.title = str(title)
@@ -427,6 +427,8 @@ class BrowserIdManager(Item, Persistent, Implicit, RoleManager, Owned, Tabs):
     @security.protected(change_browser_id_managers)
     def setCookieSameSite(self, same_site='Lax'):
         """ sets cookie 'SameSite' flag """
+
+        # Retain a way to not set the cookie at all if the admin says so
         if not same_site:
             self.cookie_same_site = None
             return

--- a/src/Products/Sessions/BrowserIdManager.py
+++ b/src/Products/Sessions/BrowserIdManager.py
@@ -144,6 +144,7 @@ class BrowserIdManager(Item, Persistent, Implicit, RoleManager, Owned, Tabs):
     # BBB
     auto_url_encoding = 0
     cookie_http_only = 0
+    cookie_same_site = None
 
     def __init__(
         self,
@@ -156,7 +157,8 @@ class BrowserIdManager(Item, Persistent, Implicit, RoleManager, Owned, Tabs):
         cookielifedays=0,
         cookiesecure=0,
         cookiehttponly=0,
-        auto_url_encoding=0
+        auto_url_encoding=0,
+        cookiesamesite=None,
     ):
         self.id = str(id)
         self.title = str(title)
@@ -168,6 +170,7 @@ class BrowserIdManager(Item, Persistent, Implicit, RoleManager, Owned, Tabs):
         self.setCookieSecure(cookiesecure)
         self.setCookieHTTPOnly(cookiehttponly)
         self.setAutoUrlEncoding(auto_url_encoding)
+        self.setCookieSameSite(cookiesamesite)
 
     # IBrowserIdManager
     @security.protected(access_contents_information)
@@ -422,6 +425,32 @@ class BrowserIdManager(Item, Persistent, Implicit, RoleManager, Owned, Tabs):
         return self.cookie_secure
 
     @security.protected(change_browser_id_managers)
+    def setCookieSameSite(self, same_site='Lax'):
+        """ sets cookie 'SameSite' flag """
+        if not same_site:
+            self.cookie_same_site = None
+            return
+
+        if same_site.lower() not in ('none', 'lax', 'strict'):
+            raise BrowserIdManagerErr(
+                'Invalid value for SameSite flag, must be one of '
+                'None, Lax or Strict.')
+
+        # Browsers reject cookies that use SameSite=None without "Secure" flag
+        # Make sure users don't shoot themselves in the foot.
+        if same_site.lower() == 'none' and not self.getCookieSecure():
+            raise BrowserIdManagerErr(
+                'Browsers require the "Secure" flag when setting '
+                'SameSite to "None".')
+
+        self.cookie_same_site = same_site
+
+    @security.protected(access_contents_information)
+    def getCookieSameSite(self):
+        """ retrieve the cookie 'SameSite' flag value """
+        return self.cookie_same_site
+
+    @security.protected(change_browser_id_managers)
     def setAutoUrlEncoding(self, auto_url_encoding):
         """ sets 'auto url encoding' on or off """
         self.auto_url_encoding = not not auto_url_encoding
@@ -462,6 +491,7 @@ class BrowserIdManager(Item, Persistent, Implicit, RoleManager, Owned, Tabs):
             'secure': self.cookie_secure,
             'http_only': self.cookie_http_only,
             'expires': expires,
+            'SameSite': self.cookie_same_site,
         }
 
         if self.cookie_secure:
@@ -551,6 +581,7 @@ class BrowserIdManager(Item, Persistent, Implicit, RoleManager, Owned, Tabs):
         cookiesecure=0,
         cookiehttponly=0,
         auto_url_encoding=0,
+        cookiesamesite=None,
         REQUEST=None
     ):
         """ """
@@ -563,6 +594,7 @@ class BrowserIdManager(Item, Persistent, Implicit, RoleManager, Owned, Tabs):
         self.setCookieHTTPOnly(cookiehttponly)
         self.setBrowserIdNamespaces(location)
         self.setAutoUrlEncoding(auto_url_encoding)
+        self.setCookieSameSite(cookiesamesite)
         self.updateTraversalData()
         if REQUEST is not None:
             msg = '/manage_browseridmgr?manage_tabs_message=Changes saved'

--- a/src/Products/Sessions/BrowserIdManager.py
+++ b/src/Products/Sessions/BrowserIdManager.py
@@ -105,12 +105,13 @@ def constructBrowserIdManager(
     cookiesecure=0,
     cookiehttponly=0,
     auto_url_encoding=0,
+    cookiesamesite='Lax',
     REQUEST=None
 ):
     """ """
     ob = BrowserIdManager(id, title, idname, location, cookiepath,
                           cookiedomain, cookielifedays, cookiesecure,
-                          cookiehttponly, auto_url_encoding)
+                          cookiehttponly, auto_url_encoding, cookiesamesite)
     self._setObject(id, ob)
     ob = self._getOb(id)
     if REQUEST is not None:

--- a/src/Products/Sessions/dtml/addIdManager.dtml
+++ b/src/Products/Sessions/dtml/addIdManager.dtml
@@ -100,7 +100,7 @@
       <label for="cookielifedays" class="col-sm-3 col-md-2">Cookie Lifetime</label>
       <div class="col-sm-9 col-md-10">
         <input id="cookielifedays" class="form-control" type="text"
-               name="cookielifedays:int" value="" />
+               name="cookielifedays:int" value="0" />
         <small>
           Cookie lifetime in days; 0 means cookies last only for
           the current browser session
@@ -128,6 +128,29 @@
           <label for="cookiehttponly">
             Make cookie not available from JavaScript
           </label>
+        </div>
+      </div>
+    </div>
+
+    <div class="form-group row">
+      <label class="col-sm-3 col-md-2">SameSite flag</label>
+      <div class="col-sm-9 col-md-10">
+        <div class="col-sm-9 col-md-10">
+          <select id="cookiesamesite" name="cookiesamesite">
+            <option value="">Not set</option>
+            <option value="None">None</option>
+            <option value="Lax" selected="selected">Lax</option>
+            <option value="Strict">Strict</option>
+          </select>
+          <br/>
+          <small>
+            The SameSite flag tells the browser where it may send the cookie.
+            "Not set" uses the browser default, "None" allows sending to third
+            parties (and **requires** the HTTPS flag to be set), "Lax" sends to
+            third parties if the user explicitly navigates to that other site,
+            and "Strict" will only ever send the cookie to the site that set it
+            in the first place. Browsers are moving to requiring at least "Lax".
+          </small>
         </div>
       </div>
     </div>

--- a/src/Products/Sessions/dtml/manageIdManager.dtml
+++ b/src/Products/Sessions/dtml/manageIdManager.dtml
@@ -135,6 +135,37 @@
       </div>
     </div>
 
+    <div class="form-group row">
+      <label class="col-sm-3 col-md-2">SameSite flag</label>
+      <div class="col-sm-9 col-md-10">
+        <div class="col-sm-9 col-md-10">
+          <select id="cookiesamesite" name="cookiesamesite">
+            <option value=""
+                    <dtml-if "not getCookieSameSite()">selected</dtml-if>>
+              Not set
+            </option>
+            <dtml-in "['None', 'Lax', 'Strict']">
+              <option value="&dtml-sequence-item;"
+                      <dtml-if "_['sequence-item'] == getCookieSameSite()">
+                        selected
+                      </dtml-if>>
+                &dtml-sequence-item;
+              </option>
+            </dtml-in>
+          </select>
+          <br/>
+          <small>
+            The SameSite flag tells the browser where it may send the cookie.
+            "Not set" uses the browser default, "None" allows sending to third
+            parties (and **requires** the HTTPS flag to be set), "Lax" sends to
+            third parties if the user explicitly navigates to that other site,
+            and "Strict" will only ever send the cookie to the site that set it
+            in the first place. Browsers are moving to requiring at least "Lax".
+          </small>
+        </div>
+      </div>
+    </div>
+
     <div class="zmi-controls mb-5">
       <input class="btn btn-primary" type="submit" name="submit" value="Change" />
     </div>

--- a/src/Products/Sessions/tests/testBrowserIdManager.py
+++ b/src/Products/Sessions/tests/testBrowserIdManager.py
@@ -110,7 +110,8 @@ class TestBrowserIdManager(unittest.TestCase):
         self.assertTrue(isAWellFormedBrowserId(bid))
         self.assertEqual(request.browser_id_, bid)
         self.assertEqual(request.browser_id_ns_, None)
-        self.assertEqual(response.cookies['bid'], {'path': '/', 'value': bid})
+        self.assertEqual(response.cookies['bid'],
+                         {'path': '/', 'value': bid, 'SameSite': 'Lax'})
 
     def test_getBrowserId_considers_replaced_characters_well_formed(self):
         bid = '92778276A8eYSMj-.iI'
@@ -212,7 +213,8 @@ class TestBrowserIdManager(unittest.TestCase):
             {
                 'path': '/',
                 'expires': 'Sun, 10-May-1971 11:59:00 GMT',
-                'value': 'deleted'
+                'value': 'deleted',
+                'SameSite': 'Lax',
             }
         )
 
@@ -232,7 +234,8 @@ class TestBrowserIdManager(unittest.TestCase):
         mgr.setBrowserIdName('bid')
         mgr.setBrowserIdNamespaces(('cookies',))
         mgr.setBrowserIdCookieByForce(bid)
-        self.assertEqual(response.cookies['bid'], {'path': '/', 'value': bid})
+        self.assertEqual(response.cookies['bid'],
+                         {'path': '/', 'value': bid, 'SameSite': 'Lax'})
 
     def test_getHiddenFormField(self):
         from ..BrowserIdManager import getNewBrowserId
@@ -385,7 +388,7 @@ class TestBrowserIdManager(unittest.TestCase):
         mgr = self._makeOne()
 
         # Test the default first
-        self.assertEqual(mgr.getCookieSameSite(), None)
+        self.assertEqual(mgr.getCookieSameSite(), 'Lax')
 
         mgr.setCookieSameSite('Strict')
         self.assertEqual(mgr.getCookieSameSite(), 'Strict')
@@ -439,6 +442,7 @@ class TestBrowserIdManager(unittest.TestCase):
                 'path': '/',
                 'value': 'xxx',
                 'expires': 'Sun, 10-May-1971 11:59:00 GMT',
+                'SameSite': 'Lax',
             }
         )
 
@@ -460,6 +464,7 @@ class TestBrowserIdManager(unittest.TestCase):
                 'path': '/',
                 'value': 'xxx',
                 'expires': 'Seconds: 86401',
+                'SameSite': 'Lax',
             }
         )
 
@@ -490,6 +495,7 @@ class TestBrowserIdManager(unittest.TestCase):
                 'path': '/',
                 'value': 'xxx',
                 'secure': True,
+                'SameSite': 'Lax',
             }
         )
 
@@ -506,6 +512,7 @@ class TestBrowserIdManager(unittest.TestCase):
                 'path': '/',
                 'value': 'xxx',
                 'domain': '.zope.org',
+                'SameSite': 'Lax',
             }
         )
 
@@ -521,6 +528,7 @@ class TestBrowserIdManager(unittest.TestCase):
             {
                 'path': '/path/',
                 'value': 'xxx',
+                'SameSite': 'Lax',
             }
         )
 
@@ -537,6 +545,7 @@ class TestBrowserIdManager(unittest.TestCase):
                 'path': '/',
                 'value': 'xxx',
                 'http_only': True,
+                'SameSite': 'Lax',
             }
         )
 
@@ -553,6 +562,7 @@ class TestBrowserIdManager(unittest.TestCase):
             {
                 'path': '/',
                 'value': 'xxx',
+                'SameSite': 'Lax',
             }
         )
 

--- a/src/Products/Sessions/tests/testBrowserIdManager.py
+++ b/src/Products/Sessions/tests/testBrowserIdManager.py
@@ -18,6 +18,8 @@ import unittest
 
 import Testing.ZopeTestCase
 
+from ..interfaces import BrowserIdManagerErr
+
 
 class TestBrowserIdManager(unittest.TestCase):
 
@@ -378,6 +380,38 @@ class TestBrowserIdManager(unittest.TestCase):
         self.assertTrue(mgr.getCookieHTTPOnly())
         mgr.setCookieHTTPOnly(False)
         self.assertFalse(mgr.getCookieHTTPOnly())
+
+    def test_setCookieSameSite(self):
+        mgr = self._makeOne()
+
+        # Test the default first
+        self.assertEqual(mgr.getCookieSameSite(), None)
+
+        mgr.setCookieSameSite('Strict')
+        self.assertEqual(mgr.getCookieSameSite(), 'Strict')
+
+        # Empty value set the flag to None
+        mgr.setCookieSameSite(None)
+        self.assertEqual(mgr.getCookieSameSite(), None)
+        mgr.setCookieSameSite('')
+        self.assertEqual(mgr.getCookieSameSite(), None)
+
+        # Reset to a known value for the following tests
+        mgr.setCookieSameSite('Strict')
+
+        # Invalid values raise an error
+        with self.assertRaises(BrowserIdManagerErr):
+            mgr.setCookieSameSite('foobar')
+        self.assertEqual(mgr.getCookieSameSite(), 'Strict')
+
+        # When specifying None the Secure flag must be set as well
+        mgr.setCookieSecure(False)
+        with self.assertRaises(BrowserIdManagerErr):
+            mgr.setCookieSameSite('None')
+        self.assertEqual(mgr.getCookieSameSite(), 'Strict')
+        mgr.setCookieSecure(True)
+        mgr.setCookieSameSite('None')
+        self.assertEqual(mgr.getCookieSameSite(), 'None')
 
     def test_setAutoUrlEncoding_bool(self):
         mgr = self._makeOne()

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands_pre =
     py27,py35: {envbindir}/buildout -nc {toxinidir}/buildout4.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     !py27-!py35: {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =
-    {envbindir}/test {posargs:-cv}
+    {envdir}/bin/test {posargs:-cv}
 
 [testenv:lint]
 basepython = python3
@@ -65,7 +65,7 @@ deps =
     coverage-python-version
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
-    coverage run {envbindir}/test {posargs:-cv}
+    coverage run {envdir}/bin/test {posargs:-cv}
     coverage html
     coverage report -m --fail-under=93
 


### PR DESCRIPTION
See https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/ for some background on how browsers change handling `SameSite`

I also updated the package configuration.
